### PR TITLE
Kill executors when stopping application

### DIFF
--- a/src/main/scala/org/apache/spark/deploy/pbs/Client.scala
+++ b/src/main/scala/org/apache/spark/deploy/pbs/Client.scala
@@ -23,6 +23,8 @@ private[pbs] class Client(args: ClientArguments, sparkConf: SparkConf) extends L
    * launching of executors on its own.
    */
   def run() {
+    // this is only called when in cluster mode which means the spark home should be the executor's
+    // spark home
     val sparkHome: String = sparkConf.getOption("spark.executor.pbs.home")
       .orElse(sparkConf.getOption("spark.home"))
       .getOrElse {

--- a/src/main/scala/org/apache/spark/deploy/pbs/ClientArguments.scala
+++ b/src/main/scala/org/apache/spark/deploy/pbs/ClientArguments.scala
@@ -68,6 +68,6 @@ private[pbs] class ClientArguments(args: Array[String]) extends Logging {
   }
 
   private def getUsageMessage(): String = {
-    "USAGE MESSAGE"
+    "USAGE MESSAGE" // TODO
   }
 }

--- a/src/main/scala/org/apache/spark/scheduler/cluster/pbs/PbsClusterManager.scala
+++ b/src/main/scala/org/apache/spark/scheduler/cluster/pbs/PbsClusterManager.scala
@@ -13,33 +13,44 @@ private[spark] class PbsClusterManager extends ExternalClusterManager with Loggi
 
   /**
    * Check if we can create scheduler components for the given URL
+   *
+   * @param master the string passed with the --master option
+   * @return if PBS can handle this master URL
    */
-  override def canCreate(masterURL: String): Boolean = {
-    /* checking if the URL starts with "pbs" e.g. "pbs://host:port" */
-    masterURL.startsWith("pbs")
+  override def canCreate(master: String): Boolean = {
+    master == "pbs"
   }
 
   /**
    * Create Task Scheduler according to the given SparkContext
+   *
+   * @param sparkContext the Spark application
+   * @return task scheduler for the application
    */
-  override def createTaskScheduler(sc: SparkContext, masterURL: String): TaskScheduler = {
+  override def createTaskScheduler(sparkContext: SparkContext, masterURL: String): TaskScheduler = {
     logDebug("Creating new TaskScheduler")
-    new TaskSchedulerImpl(sc)
+    new TaskSchedulerImpl(sparkContext)
   }
 
   /**
    * Create a Scheduler Backend for the given SparkContext
+   *
+   * @param sparkContext the Spark application
+   * @param master the string passed with the --master option
+   * @param scheduler the task scheduler for the application
    */
-  override def createSchedulerBackend(sc: SparkContext,
+  override def createSchedulerBackend(sparkContext: SparkContext,
       masterURL: String,
       scheduler: TaskScheduler): SchedulerBackend = {
-    // TODO: Check and allow for a fine grained scheduler if needed.
     logDebug("Creating new SchedulerBackend")
-    new PbsCoarseGrainedSchedulerBackend(scheduler, sc, masterURL)
+    new PbsCoarseGrainedSchedulerBackend(scheduler, sparkContext, masterURL)
   }
 
   /**
    * Initialize the Task Scheduler and Scheduler Backend (after they are created).
+   *
+   * @param scheduler the task scheduler for the application
+   * @param backend the scheduler backend to initialize
    */
   override def initialize(scheduler: TaskScheduler, backend: SchedulerBackend): Unit = {
     logDebug("Initializing Cluster Manager")

--- a/src/main/scala/org/apache/spark/scheduler/cluster/pbs/PbsCoarseGrainedSchedulerBackend.scala
+++ b/src/main/scala/org/apache/spark/scheduler/cluster/pbs/PbsCoarseGrainedSchedulerBackend.scala
@@ -18,10 +18,11 @@ private[spark] class PbsCoarseGrainedSchedulerBackend(
     sparkContext.env.rpcEnv) with Logging {
 
   private val initialExecutors: Int = SchedulerBackendUtils.getInitialTargetExecutorNumber(conf)
+  private val defaultMinRegisteredRatio: Double = 0.8
 
   protected override val minRegisteredRatio: Double = {
     if (conf.getOption("spark.scheduler.minRegisteredResourcesRatio").isEmpty) {
-      0.8
+      defaultMinRegisteredRatio
     } else {
       super.minRegisteredRatio
     }


### PR DESCRIPTION
Fixes #5 
- [x] Keep a list of executors
- [ ] Send `stop` signal to all when scheduler is stopping.