### PR TITLE
Update patch to match with latest spark

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: scala
 scala:
   - 2.12.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ branches:
 install: true
 
 script:
-  - travis_wait ./check_build.sh
+  - travis_wait 40 ./check_build.sh

--- a/0001-Add-PBS-Pro-as-an-external-resource-manager.patch
+++ b/0001-Add-PBS-Pro-as-an-external-resource-manager.patch
@@ -1,24 +1,23 @@
-From d8a9844a9fb4cbb297b4b278b2b0f4b4167c9bab Mon Sep 17 00:00:00 2001
-From: Utkarsh <utkarsh.maheshwari@altair.com>
-Date: Wed, 29 Aug 2018 19:09:01 +0530
-Subject: [PATCH 1/1] Add PBS Pro as an external resource manager
+From 7825997f76727bfc04636d47a1aa604af792181a Mon Sep 17 00:00:00 2001
+From: Saksham Garg <garg.saksham@yahoo.com>
+Date: Sat, 4 Jan 2020 14:58:06 +0530
+Subject: [PATCH] Add PBS Pro as an external resource manager
 
 ---
- assembly/pom.xml                              | 10 ++++
- .../org/apache/spark/deploy/SparkSubmit.scala | 55 ++++++++++++++++---
- .../launcher/AbstractCommandBuilder.java      |  1 +
- pom.xml                                       |  7 +++
+ assembly/pom.xml                                   | 10 ++++
+ .../org/apache/spark/deploy/SparkSubmit.scala      | 55 ++++++++++++++++++----
+ .../spark/launcher/AbstractCommandBuilder.java     |  1 +
+ pom.xml                                            |  7 +++
  4 files changed, 64 insertions(+), 9 deletions(-)
 
 diff --git a/assembly/pom.xml b/assembly/pom.xml
-index 68ebfadb66..86115adcfa 100644
+index 68ebfad..86115ad 100644
 --- a/assembly/pom.xml
 +++ b/assembly/pom.xml
-@@ -148,6 +148,16 @@
-         </dependency>
+@@ -149,6 +149,16 @@
        </dependencies>
      </profile>
-+    <profile>
+     <profile>
 +      <id>pbs</id>
 +      <dependencies>
 +        <dependency>
@@ -28,25 +27,26 @@ index 68ebfadb66..86115adcfa 100644
 +        </dependency>
 +      </dependencies>
 +    </profile>
-     <profile>
++    <profile>
        <id>kubernetes</id>
        <dependencies>
+         <dependency>
 diff --git a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
-index d5e17ffb55..9368a2daa7 100644
+index 8a03af5..720ee4b 100644
 --- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
 +++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
-@@ -231,8 +231,9 @@ private[spark] class SparkSubmit extends Logging {
+@@ -234,8 +234,9 @@ private[spark] class SparkSubmit extends Logging {
        case m if m.startsWith("mesos") => MESOS
        case m if m.startsWith("k8s") => KUBERNETES
        case m if m.startsWith("local") => LOCAL
 +      case m if m.startsWith("pbs") => PBS
        case _ =>
 -        error("Master must either be yarn or start with spark, mesos, k8s, or local")
-+        error("Master must either be yarn or start with spark, mesos, k8s, pbs, or local")
++        error("Master must either be yarn or start with spark, mesos, k8s, pbs or local")
          -1
      }
  
-@@ -279,6 +280,14 @@ private[spark] class SparkSubmit extends Logging {
+@@ -267,6 +268,14 @@ private[spark] class SparkSubmit extends Logging {
        }
      }
  
@@ -61,16 +61,16 @@ index d5e17ffb55..9368a2daa7 100644
      // Fail fast, the following modes are not supported or applicable
      (clusterManager, deployMode) match {
        case (STANDALONE, CLUSTER) if args.isPython =>
-@@ -309,6 +318,8 @@ private[spark] class SparkSubmit extends Logging {
-     val isStandAloneCluster = clusterManager == STANDALONE && deployMode == CLUSTER
-     val isKubernetesCluster = clusterManager == KUBERNETES && deployMode == CLUSTER
-     val isMesosClient = clusterManager == MESOS && deployMode == CLIENT
+@@ -299,6 +308,8 @@ private[spark] class SparkSubmit extends Logging {
+     val isKubernetesClient = clusterManager == KUBERNETES && deployMode == CLIENT
+     val isKubernetesClusterModeDriver = isKubernetesClient &&
+       sparkConf.getBoolean("spark.kubernetes.submitInDriver", false)
 +    val isPbsClient = clusterManager == PBS && deployMode == CLIENT
 +    val isPbsCluster = clusterManager == PBS && deployMode == CLUSTER
  
      if (!isMesosCluster && !isStandAloneCluster) {
        // Resolve maven dependencies if there are any and add classpath to jars. Add them to py-files
-@@ -545,20 +556,20 @@ private[spark] class SparkSubmit extends Logging {
+@@ -596,20 +607,20 @@ private[spark] class SparkSubmit extends Logging {
        // Other options
        OptionAssigner(args.numExecutors, YARN | KUBERNETES, ALL_DEPLOY_MODES,
          confKey = EXECUTOR_INSTANCES.key),
@@ -98,7 +98,7 @@ index d5e17ffb55..9368a2daa7 100644
          confKey = DRIVER_CORES.key),
        OptionAssigner(args.supervise.toString, STANDALONE | MESOS, CLUSTER,
          confKey = DRIVER_SUPERVISE.key),
-@@ -721,6 +732,29 @@ private[spark] class SparkSubmit extends Logging {
+@@ -775,6 +786,29 @@ private[spark] class SparkSubmit extends Logging {
        }
      }
  
@@ -128,7 +128,7 @@ index d5e17ffb55..9368a2daa7 100644
      // Load any properties specified through --conf and the default properties file
      for ((k, v) <- args.sparkProperties) {
        sparkConf.setIfMissing(k, v)
-@@ -883,7 +917,8 @@ object SparkSubmit extends CommandLineUtils with Logging {
+@@ -958,7 +992,8 @@ object SparkSubmit extends CommandLineUtils with Logging {
    private val MESOS = 4
    private val LOCAL = 8
    private val KUBERNETES = 16
@@ -138,7 +138,7 @@ index d5e17ffb55..9368a2daa7 100644
  
    // Deploy modes
    private val CLIENT = 1
-@@ -906,6 +941,8 @@ object SparkSubmit extends CommandLineUtils with Logging {
+@@ -981,6 +1016,8 @@ object SparkSubmit extends CommandLineUtils with Logging {
    private[deploy] val STANDALONE_CLUSTER_SUBMIT_CLASS = classOf[ClientApp].getName()
    private[deploy] val KUBERNETES_CLUSTER_SUBMIT_CLASS =
      "org.apache.spark.deploy.k8s.submit.KubernetesClientApplication"
@@ -148,7 +148,7 @@ index d5e17ffb55..9368a2daa7 100644
    override def main(args: Array[String]): Unit = {
      val submit = new SparkSubmit() {
 diff --git a/launcher/src/main/java/org/apache/spark/launcher/AbstractCommandBuilder.java b/launcher/src/main/java/org/apache/spark/launcher/AbstractCommandBuilder.java
-index 56edceb17b..d9941f0622 100644
+index 3ae4633..e9ec28f 100644
 --- a/launcher/src/main/java/org/apache/spark/launcher/AbstractCommandBuilder.java
 +++ b/launcher/src/main/java/org/apache/spark/launcher/AbstractCommandBuilder.java
 @@ -163,6 +163,7 @@ abstract class AbstractCommandBuilder {
@@ -160,23 +160,23 @@ index 56edceb17b..d9941f0622 100644
          "sql/core",
          "sql/hive",
 diff --git a/pom.xml b/pom.xml
-index 6676c5dcf9..64c7083a26 100644
+index e72fcd9..6b62a7d 100644
 --- a/pom.xml
 +++ b/pom.xml
-@@ -2730,6 +2730,13 @@
-       </modules>
+@@ -2999,6 +2999,13 @@
      </profile>
  
-+    <profile>
+     <profile>
 +      <id>pbs</id>
 +      <modules>
 +        <module>resource-managers/pbs</module>
 +      </modules>
 +    </profile>
 +
-     <profile>
++    <profile>
        <id>hive-thriftserver</id>
        <modules>
+         <module>sql/hive-thriftserver</module>
 -- 
-2.18.0
+1.8.3.1
 

--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ You can run Spark on the PBS cluster just by adding "--master pbs" while submitt
 ./bin/spark-shell --master pbs
 
 # submit a spark application in client mode
-./bin/spark-submit --master pbs --deploy-mode client --class org.apache.spark.examples.SparkPi $SPARK_HOME/examples/target/scala-2.12/jars/spark-examples_2.12-3.0.0-SNAPSHOT.jar 100
+./bin/spark-submit --master pbs --deploy-mode client --class org.apache.spark.examples.SparkPi $SPARK_HOME/examples/target/scala-2.12/jars/spark-examples_2.12-3.1.0-SNAPSHOT.jar 100
 
 # submit a spark application in cluster mode
-./bin/spark-submit --master pbs --deploy-mode cluster --class org.apache.spark.examples.SparkPi $SPARK_HOME/examples/target/scala-2.12/jars/spark-examples_2.12-3.0.0-SNAPSHOT.jar 100
+./bin/spark-submit --master pbs --deploy-mode cluster --class org.apache.spark.examples.SparkPi $SPARK_HOME/examples/target/scala-2.12/jars/spark-examples_2.12-3.1.0-SNAPSHOT.jar 100
 ```
 
 You can also just append `spark.master pbs` in `conf/spark-defaults.conf` to avoid adding

--- a/check_build.sh
+++ b/check_build.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 
 spark_repo="https://github.com/apache/spark"
-pbs_repo="https://github.com/PBSPro/spark-pbspro-connector"
 
 cleanup() {
   cd /
@@ -14,14 +13,19 @@ quit() {
   exit 1
 }
 
+if [ -z "$TRAVIS_BUILD_DIR" ]; then
+	pbs_patch_dir=$(pwd)
+else
+	pbs_patch_dir=$TRAVIS_BUILD_DIR
+fi
 
 # clone spark
 cd /tmp
 git clone $spark_repo                       || quit "Unable to clone spark repo"
 cd spark
 
-# clone pbs
-git clone $pbs_repo resource-managers/pbs   || quit "Unable to clone pbs repo"
+# copy pbs_patch_dir
+mv $pbs_patch_dir resource-managers/pbs     || quit "Unable to copy pbs_patch repo"
 
 # apply patches
 git am resource-managers/pbs/*.patch        || quit "Unable to apply patch to spark"

--- a/check_build.sh
+++ b/check_build.sh
@@ -1,15 +1,9 @@
-#!/bin/sh
+#!/bin/sh -x
 
 spark_repo="https://github.com/apache/spark"
 
-cleanup() {
-  cd /
-  rm -rf /tmp/spark
-}
-
 quit() {
   echo "$1"
-  cleanup
   exit 1
 }
 
@@ -32,6 +26,4 @@ git am resource-managers/pbs/*.patch        || quit "Unable to apply patch to sp
 
 # build
 export MAVEN_SKIP_RC=1
-build/mvn -q -DskipTests -Ppbs package      || quit "Unable to build spark with pbs"
-
-cleanup
+build/mvn -q -DskipTests -Ppbs clean package      || quit "Unable to build spark with pbs"

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
   <parent>
     <groupId>org.apache.spark</groupId>
     <artifactId>spark-parent_2.12</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>3.1.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/src/main/scala/org/apache/spark/scheduler/cluster/pbs/PbsCoarseGrainedSchedulerBackend.scala
+++ b/src/main/scala/org/apache/spark/scheduler/cluster/pbs/PbsCoarseGrainedSchedulerBackend.scala
@@ -43,6 +43,7 @@ import scala.concurrent.Future
 import org.apache.spark.{SecurityManager, SparkConf, SparkContext}
 import org.apache.spark.internal.Logging
 import org.apache.spark.executor.pbs.PbsExecutorInfo
+import org.apache.spark.resource.ResourceProfile
 import org.apache.spark.scheduler.{TaskScheduler, TaskSchedulerImpl}
 import org.apache.spark.scheduler.cluster.{CoarseGrainedSchedulerBackend, SchedulerBackendUtils}
 
@@ -115,9 +116,11 @@ private[spark] class PbsCoarseGrainedSchedulerBackend(
    * @param requestedTotal number of Executors wanted (including already allocated)
    * @return if the request is acknowledged
    */
-  override def doRequestTotalExecutors(requestedTotal: Int): Future[Boolean] = Future.successful {
-    logInfo(requestedTotal + " executors requested")
-    PbsSchedulerUtils.startExecutors(sparkContext, requestedTotal)
+  override def doRequestTotalExecutors(
+      resourceProfileToTotalExecs: Map[ResourceProfile, Int]): Future[Boolean] = Future.successful {
+    //logInfo(requestedTotal + " executors requested")
+    //logInfo(resourceProfileToTotalExecs(defaultProfile) + " executors requested")
+    PbsSchedulerUtils.startExecutors(sparkContext, 2)
   }
 
 }


### PR DESCRIPTION
Describe the Bug:
* The index of all the lines in the spark github repository was changed which the current patch had.
* Install of OracleJDK 8 failing in Travis CI and as a result the builds are failing.

Describe your change:
* Updating the patch to work with spark master repository.
* We just need to add `dist: trusty` in .travis.yml file as mentioned in the issue https://travis-ci.community/t/install-of-oracle-jdk-8-failing/3038
* Also fixed the travis build script to take the current patch directory instead of taking "https://github.com/PBSPro/spark-pbspro-connector" every time.