### PR TITLE
Fix for oraclejdk8 in travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: scala
 scala:
   - 2.12.7


### PR DESCRIPTION
* Describe Bug:
Install of OracleJDK 8 failing in Travis CI and as a result the builds are failing.

* Describe your change:
We just need to add `dist: trusty` in .travis.yml file as mentioned in the issue https://travis-ci.community/t/install-of-oracle-jdk-8-failing/3038